### PR TITLE
Enable `/guns` menu when starter weapons not set in config

### DIFF
--- a/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_equip_manager.sma
+++ b/cstrike/addons/amxmodx/scripting/CSDM_ReAPI/csdm_equip_manager.sma
@@ -204,7 +204,9 @@ public client_putinserver(pPlayer)
 {
 	g_iPreviousSecondary[pPlayer] = g_iStarterSecondary
 	g_iPreviousPrimary[pPlayer] = g_iStarterPrimary
-	g_bOpenMenu[pPlayer] = false
+
+	g_bOpenMenu[pPlayer] = (g_iStarterPrimary == INVALID_INDEX && g_iStarterSecondary == INVALID_INDEX)
+
 	g_bAlwaysRandom[pPlayer] = false
 	g_flPlayerBuyTime[pPlayer] = 0.0
 }


### PR DESCRIPTION
Usage: 
```ini
; Starter weapons for players
; Can only put weapons available from Equip Menu
starter_secondary = ""
starter_primary = ""
```